### PR TITLE
Dominion 5 Inspector search links

### DIFF
--- a/app/controllers/dominions4bot_controller.rb
+++ b/app/controllers/dominions4bot_controller.rb
@@ -256,4 +256,30 @@ logger.info "\n\n\n\n\n\n #{player_name}\n\n\n\n\n\n"
     respond_with :message, text: "Ups!\n\n```#{e.message}```\nNada que ver, circulen...", parse_mode: :Markdown
   end
 
+
+  INSPECTOR_TABS = {
+    item: %w{item i objeto},
+    spell: %w{spell s hechizo},
+    unit: %w{unit u unidad},
+    site: %w{site s lugar},
+    merc: %w{merc m mercenaries mercenary mercenario mercenarios},
+    event: %w{event e eventos}
+  }
+  # somos flexibles con las categorías de búsqueda
+  SEARCH_TERMS = INSPECTOR_TABS.map do |k, vs|
+    vs.map { |v| [v, k.to_s] }
+  end.flatten(1).to_h
+
+  DEFAULT_TERMS = INSPECTOR_TABS.map {|_, vs| vs.first }
+
+  def busca!(*search_terms)
+    page = search_terms.shift if search_terms.length > 2
+    if page.nil?
+      respond_with :message, text "Puedes buscar por #{DEFAULT_TERMS.join(', ')};\nPorfi incluye términos de búsqueda :)"
+    else
+      search = search_terms.join(' ')
+      link = "https://larzm42.github.io/dom5inspector/?page=#{page}&#{page}q=#{search}"
+      respond_with :message, text: link, parse_mode: :Markdown
+    end
+  end
 end

--- a/app/controllers/dominions4bot_controller.rb
+++ b/app/controllers/dominions4bot_controller.rb
@@ -265,7 +265,7 @@ logger.info "\n\n\n\n\n\n #{player_name}\n\n\n\n\n\n"
     merc: %w{merc m mercenaries mercenary mercenario mercenarios},
     event: %w{event e eventos}
   }
-  # somos flexibles con las categorías de búsqueda
+  # we're flexible with the search areas used
   SEARCH_TERMS = INSPECTOR_TABS.map do |k, vs|
     vs.map { |v| [v, k.to_s] }
   end.flatten(1).to_h

--- a/app/controllers/dominions4bot_controller.rb
+++ b/app/controllers/dominions4bot_controller.rb
@@ -273,7 +273,8 @@ logger.info "\n\n\n\n\n\n #{player_name}\n\n\n\n\n\n"
   DEFAULT_TERMS = INSPECTOR_TABS.map {|_, vs| vs.first }
 
   def busca!(*search_terms)
-    page = search_terms.shift if search_terms.length > 2
+    area = search_terms.shift if search_terms.length > 2
+    page = SEARCH_TERMS[area] if area
     if page.nil?
       respond_with :message, text "Puedes buscar por #{DEFAULT_TERMS.join(', ')};\nPorfi incluye términos de búsqueda :)"
     else

--- a/app/controllers/dominions4bot_controller.rb
+++ b/app/controllers/dominions4bot_controller.rb
@@ -4,7 +4,6 @@ class Dominions4botController < Telegram::Bot::UpdatesController
   EXCUSES = [ "A mi que me cuentas, diselo a Pedro que fijo que es culpa suya",
               "Yo que sé, ataca a Dani",
               "No dejes que Tien Chi llegue al late game",
-              "Aco? Sí sí, claro que iba a jugar",
               "Recuerda, un Panda siempre paga sus deudas",
               "No le hagas caso",
               "Creo que te voy a ignorar eso que has dicho",


### PR DESCRIPTION
Adds a link in the chat to the searched items in dominions inspector. Yes going to the page is easy, but for discussions it is handy to be able to post the link directly while talking. Other similar game (and non-game) bots usually have such functionality and I have seen it used a lot. 

Also, should be part of another PR, but I removed a non valid excuse ;) .